### PR TITLE
Update README npm start address

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ In the project directory, you can run:
 ### `npm start`
 
 Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
+Open [http://localhost:3011](http://localhost:3011) to view it in your browser.
 
 The page will reload when you make changes.\
 You may also see any lint errors in the console.


### PR DESCRIPTION
## Summary
- update the README `npm start` instructions to use port 3011

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684992b4e128832d82170f6b2d9187eb