### PR TITLE
Add WinnerTypo component tests

### DIFF
--- a/src/component/WinnerTypo.test.tsx
+++ b/src/component/WinnerTypo.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import WinnerTypo from './WinnerTypo';
+
+describe('WinnerTypo', () => {
+  test('displays plaintiff name when win="plaintiff"', () => {
+    render(<WinnerTypo win="plaintiff" plaintiff="John" defendant="Jane" />);
+    expect(screen.getByText('John')).toBeInTheDocument();
+  });
+
+  test('displays defendant name when win="defendant"', () => {
+    render(<WinnerTypo win="defendant" plaintiff="John" defendant="Jane" />);
+    expect(screen.getByText('Jane')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for WinnerTypo component

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849938fb720832d991562b5ea38ce82