### PR TITLE
Integrate upload into discussion page

### DIFF
--- a/src/component/TemporaryDrawer.tsx
+++ b/src/component/TemporaryDrawer.tsx
@@ -91,15 +91,6 @@ export default function TemporaryDrawer() {
                         <ListItemText primary="討論區" />
                     </ListItemButton>
                 </ListItem>
-                {/* 上傳案例 */}
-                <ListItem disablePadding>
-                    <ListItemButton component={RouterLink} to="/upload">
-                        <ListItemIcon>
-                            <InboxIcon />
-                        </ListItemIcon>
-                        <ListItemText primary="上傳案例" />
-                    </ListItemButton>
-                </ListItem>
                 <Link
                     href="https://www.facebook.com/profile.php?id=100093981245377"
                     target="_blank"

--- a/src/pages/DiscussionPage.tsx
+++ b/src/pages/DiscussionPage.tsx
@@ -1,12 +1,14 @@
-import React, { useEffect } from 'react';
-import { Typography, Box } from '@mui/material';
+import React, { useEffect, useState } from 'react';
+import { Typography, Box, Button } from '@mui/material';
 import CaseCardList from '../component/CaseCardList';
 import { useAppDispatch, useAppSelector } from '../hooks/redux';
 import { fetchCaseList } from '../redux/caseSlice';
+import UploadCasePage from './UploadCasePage';
 
 export default function DiscussionPage() {
     const dispatch = useAppDispatch();
     const cases = useAppSelector((s) => s.cases.list);
+    const [showUpload, setShowUpload] = useState(false);
 
     useEffect(() => {
         dispatch(fetchCaseList({}));
@@ -14,10 +16,28 @@ export default function DiscussionPage() {
 
     return (
         <Box sx={{ mt: '-48px', p: 2 }}>
-            <Typography variant="h4" gutterBottom textAlign="center">
-                討論區
-            </Typography>
-            <CaseCardList items={cases} />
+            {showUpload ? (
+                <UploadCasePage
+                    onComplete={() => {
+                        setShowUpload(false);
+                        dispatch(fetchCaseList({}));
+                    }}
+                />
+            ) : (
+                <>
+                    <Typography variant="h4" gutterBottom textAlign="center">
+                        討論區
+                    </Typography>
+                    <Button
+                        variant="contained"
+                        sx={{ mb: 2 }}
+                        onClick={() => setShowUpload(true)}
+                    >
+                        上傳案例
+                    </Button>
+                    <CaseCardList items={cases} />
+                </>
+            )}
         </Box>
     );
 }

--- a/src/pages/UploadCasePage.tsx
+++ b/src/pages/UploadCasePage.tsx
@@ -13,7 +13,11 @@ import { uploadCase, resetStatus } from '../redux/uploadSlice';
 import { setShowDialog } from '../redux/phoneSlice';
 import { USER_DIALOG_STATUS } from '../types/enums';
 
-export default function UploadCasePage() {
+export interface UploadCasePageProps {
+    onComplete?: () => void;
+}
+
+export default function UploadCasePage({ onComplete }: UploadCasePageProps) {
     const dispatch = useAppDispatch();
     const { status, error } = useAppSelector((s) => s.upload);
     const isLoggedIn = useAppSelector((s) => s.user.isLoggedIn);
@@ -53,6 +57,9 @@ export default function UploadCasePage() {
     };
 
     const handleClose = () => {
+        if (status === 'succeeded' && onComplete) {
+            onComplete();
+        }
         dispatch(resetStatus());
     };
 


### PR DESCRIPTION
## Summary
- add callback support in `UploadCasePage`
- add upload button on discussion page and render form conditionally
- remove upload link from the drawer

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685288939070832dab7a487a9b1fa030