### PR TITLE
Hide comments until toggled

### DIFF
--- a/src/component/CaseCard.tsx
+++ b/src/component/CaseCard.tsx
@@ -53,6 +53,7 @@ const CaseCard: React.FC<Props> = ({ item }) => {
 
     const images = item.imageUrls || item.images || [];
     const [viewerIndex, setViewerIndex] = useState<number | null>(null);
+    const [showComments, setShowComments] = useState(false);
 
     const openViewer = (idx: number) => {
         setViewerIndex(idx);
@@ -125,7 +126,7 @@ const CaseCard: React.FC<Props> = ({ item }) => {
                     {loading ? <CircularProgress size={24} /> : <FavoriteIcon />}
                     <Typography sx={{ ml: 0.5 }}>{likeCount}</Typography>
                 </IconButton>
-                <IconButton>
+                <IconButton onClick={() => setShowComments((prev) => !prev)}>
                     <CommentIcon />
                     <Typography sx={{ ml: 0.5 }}>{comments.length}</Typography>
                 </IconButton>
@@ -136,7 +137,7 @@ const CaseCard: React.FC<Props> = ({ item }) => {
                         {item.content}
                     </Typography>
                 )}
-                <CaseComments caseId={item.id} />
+                {showComments && <CaseComments caseId={item.id} />}
             </CardContent>
             {images.length > 0 && (
                 <Dialog open={viewerIndex !== null} onClose={closeViewer}>


### PR DESCRIPTION
## Summary
- hide comments in case cards until user toggles them

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b6870ffc832d88d417234c9b617d