### PR TITLE
Move upload button to floating Fab

### DIFF
--- a/src/pages/DiscussionPage.tsx
+++ b/src/pages/DiscussionPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { Typography, Box, Button } from '@mui/material';
+import { Typography, Box, Fab } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
 import CaseCardList from '../component/CaseCardList';
 import { useAppDispatch, useAppSelector } from '../hooks/redux';
 import { fetchCaseList } from '../redux/caseSlice';
@@ -28,13 +29,19 @@ export default function DiscussionPage() {
                     <Typography variant="h4" gutterBottom textAlign="center">
                         討論區
                     </Typography>
-                    <Button
-                        variant="contained"
-                        sx={{ mb: 2 }}
+                    <Fab
+                        color="primary"
+                        aria-label="add"
+                        sx={{
+                            position: 'fixed',
+                            bottom: 16,
+                            right: 16,
+                            zIndex: 1000,
+                        }}
                         onClick={() => setShowUpload(true)}
                     >
-                        上傳案例
-                    </Button>
+                        <AddIcon />
+                    </Fab>
                     <CaseCardList items={cases} />
                 </>
             )}


### PR DESCRIPTION
## Summary
- move the discussion page upload button to a floating action button at bottom right

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852c65ebc90832d8d75cfa74549712c