### PR TITLE
Add back button on upload page

### DIFF
--- a/src/pages/UploadCasePage.tsx
+++ b/src/pages/UploadCasePage.tsx
@@ -7,8 +7,10 @@ import {
     Button,
     Snackbar,
     Alert,
+    Fab,
 } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
+import CloseIcon from '@mui/icons-material/Close';
 import { useAppDispatch, useAppSelector } from '../hooks/redux';
 import { uploadCase, resetStatus } from '../redux/uploadSlice';
 import { setShowDialog } from '../redux/phoneSlice';
@@ -75,9 +77,19 @@ export default function UploadCasePage({ onComplete }: UploadCasePageProps) {
 
     return (
         <Container sx={{ py: 4 }}>
-            <Button variant="outlined" sx={{ mb: 2 }} onClick={handleBack}>
-                回到討論區
-            </Button>
+            <Fab
+                color="primary"
+                aria-label="close"
+                onClick={handleBack}
+                sx={{
+                    position: 'fixed',
+                    bottom: 16,
+                    right: 16,
+                    zIndex: 1000,
+                }}
+            >
+                <CloseIcon />
+            </Fab>
             <Typography variant="h4" gutterBottom>
                 上傳案例
             </Typography>

--- a/src/pages/UploadCasePage.tsx
+++ b/src/pages/UploadCasePage.tsx
@@ -8,6 +8,7 @@ import {
     Snackbar,
     Alert,
 } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '../hooks/redux';
 import { uploadCase, resetStatus } from '../redux/uploadSlice';
 import { setShowDialog } from '../redux/phoneSlice';
@@ -19,6 +20,7 @@ export interface UploadCasePageProps {
 
 export default function UploadCasePage({ onComplete }: UploadCasePageProps) {
     const dispatch = useAppDispatch();
+    const navigate = useNavigate();
     const { status, error } = useAppSelector((s) => s.upload);
     const isLoggedIn = useAppSelector((s) => s.user.isLoggedIn);
 
@@ -63,8 +65,19 @@ export default function UploadCasePage({ onComplete }: UploadCasePageProps) {
         dispatch(resetStatus());
     };
 
+    const handleBack = () => {
+        if (onComplete) {
+            onComplete();
+        } else {
+            navigate(-1);
+        }
+    };
+
     return (
         <Container sx={{ py: 4 }}>
+            <Button variant="outlined" sx={{ mb: 2 }} onClick={handleBack}>
+                回到討論區
+            </Button>
             <Typography variant="h4" gutterBottom>
                 上傳案例
             </Typography>


### PR DESCRIPTION
## Summary
- enable navigation back to the discussion area from UploadCasePage

## Testing
- `npm test --silent -- -w 1` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68534434acf8832d8cd57f3948b7fc09