### PR TITLE
Remove homepage no-data message

### DIFF
--- a/src/component/CaseList.tsx
+++ b/src/component/CaseList.tsx
@@ -44,12 +44,7 @@ function ExampleList(props: Props) {
         setSelectedItem(null);
         setOpenCommentId(null);
     };
-    if (items.length === 0)
-        return (
-            <Typography gutterBottom variant="h5" component="h2">
-                查無資料
-            </Typography>
-        );
+    if (items.length === 0) return null;
 
     return (
         <>


### PR DESCRIPTION
## Summary
- remove '查無資料' message from `CaseList`

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685421227f90832d990d31e9f3a1ed29