### PR TITLE
Fix image viewer to show full image

### DIFF
--- a/src/component/CaseCard.tsx
+++ b/src/component/CaseCard.tsx
@@ -143,9 +143,28 @@ const CaseCard: React.FC<Props> = ({ item }) => {
             </CardContent>
             {images.length > 0 && (
                 <Dialog open={viewerIndex !== null} onClose={closeViewer}>
-                    <DialogContent sx={{ p: 0 }}>
+                    <DialogContent
+                        sx={{
+                            p: 0,
+                            display: 'flex',
+                            justifyContent: 'center',
+                            alignItems: 'center',
+                        }}
+                    >
                         {viewerIndex !== null && (
-                            <Box sx={{ position: 'relative', textAlign: 'center' }}>
+                            <Box
+                                sx={{
+                                    position: 'relative',
+                                    textAlign: 'center',
+                                    maxWidth: '80vw',
+                                    maxHeight: '80vh',
+                                    m: 'auto',
+                                    overflow: 'hidden',
+                                    display: 'flex',
+                                    justifyContent: 'center',
+                                    alignItems: 'center',
+                                }}
+                            >
                                 <IconButton
                                     onClick={showPrev}
                                     disabled={images.length <= 1}
@@ -162,9 +181,10 @@ const CaseCard: React.FC<Props> = ({ item }) => {
                                     component="img"
                                     src={images[viewerIndex]}
                                     sx={{
-                                        maxWidth: '80vw',
-                                        maxHeight: '80vh',
+                                        maxWidth: '100%',
+                                        maxHeight: '100%',
                                         objectFit: 'contain',
+                                        display: 'block',
                                     }}
                                 />
                                 <IconButton

--- a/src/component/CaseCard.tsx
+++ b/src/component/CaseCard.tsx
@@ -143,7 +143,7 @@ const CaseCard: React.FC<Props> = ({ item }) => {
             </CardContent>
             {images.length > 0 && (
                 <Dialog open={viewerIndex !== null} onClose={closeViewer}>
-                    <DialogContent>
+                    <DialogContent sx={{ p: 0 }}>
                         {viewerIndex !== null && (
                             <Box sx={{ position: 'relative', textAlign: 'center' }}>
                                 <IconButton
@@ -161,7 +161,11 @@ const CaseCard: React.FC<Props> = ({ item }) => {
                                 <Box
                                     component="img"
                                     src={images[viewerIndex]}
-                                    sx={{ maxWidth: '80vw', maxHeight: '80vh' }}
+                                    sx={{
+                                        maxWidth: '80vw',
+                                        maxHeight: '80vh',
+                                        objectFit: 'contain',
+                                    }}
                                 />
                                 <IconButton
                                     onClick={showNext}


### PR DESCRIPTION
## Summary
- show entire image in CaseCard viewer by using `objectFit: contain`
- remove padding in the viewer dialog

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855450768e8832d963eeecfbd233857