### PR TITLE
Align discussion card width

### DIFF
--- a/src/component/CaseCard.tsx
+++ b/src/component/CaseCard.tsx
@@ -95,7 +95,7 @@ const CaseCard: React.FC<Props> = ({ item }) => {
     };
 
     return (
-        <Card sx={{ width: '100%', maxWidth: 600, mb: 3 }}>
+        <Card sx={{ width: '50vw', minWidth: 400, mb: 3 }}>
             <CardHeader
                 title={item.title || `被告：${item.defendantName}`}
                 subheader={`被告：${item.defendantName} / 電話：${item.defendantPhone} / 身分證：${item.defendantIdNo}${item.location ? ` / 地點：${item.location}${item.district || ''}` : ''}`}


### PR DESCRIPTION
## Summary
- make discussion cards match homepage card width

## Testing
- `npm test -- -w=0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855488f8fb0832d886d7eb7ba8d497f