### PR TITLE
Fix like status retrieval

### DIFF
--- a/src/redux/caseLikeSlice.ts
+++ b/src/redux/caseLikeSlice.ts
@@ -26,7 +26,7 @@ export const fetchCaseLikeStatus = createAsyncThunk<
         if (token) {
             const config = { headers: { Authorization: `Bearer ${token}` } };
             const resp = await axios.get<{ liked: boolean }>(
-                `${CASE_API_URL}/${caseId}/like`,
+                `${CASE_API_URL}/${caseId}/like/status`,
                 config,
             );
             return { caseId, liked: resp.data.liked };

--- a/src/redux/caseLikeSlice.ts
+++ b/src/redux/caseLikeSlice.ts
@@ -26,7 +26,7 @@ export const fetchCaseLikeStatus = createAsyncThunk<
         if (token) {
             const config = { headers: { Authorization: `Bearer ${token}` } };
             const resp = await axios.get<{ liked: boolean }>(
-                `${CASE_API_URL}/${caseId}`,
+                `${CASE_API_URL}/${caseId}/like`,
                 config,
             );
             return { caseId, liked: resp.data.liked };


### PR DESCRIPTION
## Summary
- adjust API path for case like status

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855679cc518832d91c9447525c52b1b