### PR TITLE
Fix comment count on discussion posts

### DIFF
--- a/src/component/CaseCard.tsx
+++ b/src/component/CaseCard.tsx
@@ -24,7 +24,10 @@ import {
     fetchCaseLikeStatus,
     toggleCaseLike,
 } from '../redux/caseLikeSlice';
-import { selectCaseComments } from '../redux/caseCommentSlice';
+import {
+    fetchCaseComments,
+    selectCaseComments,
+} from '../redux/caseCommentSlice';
 import { setShowDialog } from '../redux/phoneSlice';
 import { USER_DIALOG_STATUS } from '../types/enums';
 
@@ -92,6 +95,7 @@ const CaseCard: React.FC<Props> = ({ item }) => {
     useEffect(() => {
         dispatch(fetchCaseLikeCount(item.id));
         dispatch(fetchCaseLikeStatus(item.id));
+        dispatch(fetchCaseComments(item.id));
     }, [dispatch, item.id]);
 
     const handleToggleLike = () => {


### PR DESCRIPTION
## Summary
- load comments when a discussion post card mounts so the count is correct

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68560648359c832d80029efc523faaf2