### PR TITLE
Add IP display in case cards

### DIFF
--- a/src/component/CaseCard.tsx
+++ b/src/component/CaseCard.tsx
@@ -49,6 +49,7 @@ export interface CaseData {
     district?: string;
     images?: string[];
     imageUrls?: string[];
+    ip?: string;
 }
 
 interface Props {
@@ -118,6 +119,9 @@ const CaseCard: React.FC<Props> = ({ item }) => {
                                 地點：{item.location}
                                 {item.district || ''}
                             </Typography>
+                        )}
+                        {item.ip && (
+                            <Typography variant="body2">IP：{item.ip}</Typography>
                         )}
                     </Box>
                 }


### PR DESCRIPTION
## Summary
- show uploader IP on discussion case cards

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857ca5603d0832d83c4c6b1a087349e