### PR TITLE
Fix comment count on discussion cards

### DIFF
--- a/src/component/CaseCard.tsx
+++ b/src/component/CaseCard.tsx
@@ -24,7 +24,7 @@ import {
     fetchCaseLikeStatus,
     toggleCaseLike,
 } from '../redux/caseLikeSlice';
-import { selectCaseComments } from '../redux/caseCommentSlice';
+import { selectCaseComments, fetchCaseComments } from '../redux/caseCommentSlice';
 import { setShowDialog } from '../redux/phoneSlice';
 import { USER_DIALOG_STATUS } from '../types/enums';
 
@@ -93,6 +93,7 @@ const CaseCard: React.FC<Props> = ({ item }) => {
     useEffect(() => {
         dispatch(fetchCaseLikeCount(item.id));
         dispatch(fetchCaseLikeStatus(item.id));
+        dispatch(fetchCaseComments(item.id));
     }, [dispatch, item.id]);
 
     const handleToggleLike = () => {


### PR DESCRIPTION
## Summary
- prefetch comments when rendering case cards so comment count shows

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858a6c2867c832d83e83672370c8660