### PR TITLE
Add date after location in discussion cards

### DIFF
--- a/src/component/CaseCard.tsx
+++ b/src/component/CaseCard.tsx
@@ -121,9 +121,9 @@ const CaseCard: React.FC<Props> = ({ item }) => {
                                 地點：{item.location}
                                 {item.district || ''}
                                 {item.createdAt
-                                    ? ` 時間：${new Date(item.createdAt).toLocaleDateString()}`
+                                    ? `，時間：${new Date(item.createdAt).toLocaleDateString()}`
                                     : ''}
-                                {item.ip ? ` 來自：${item.ip}` : ''}
+                                {item.ip ? `，來自：${item.ip}` : ''}
                             </Typography>
                         )}
                     </Box>

--- a/src/component/CaseCard.tsx
+++ b/src/component/CaseCard.tsx
@@ -114,7 +114,7 @@ const CaseCard: React.FC<Props> = ({ item }) => {
                 subheader={
                     <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                         <Typography variant="body2">
-                            姓名：{maskName(item.defendantName)} / 電話：{maskPhone(item.defendantPhone)} / 身分證：{maskId(item.defendantIdNo)}
+                            姓名：{maskName(item.defendantName)}，電話：{maskPhone(item.defendantPhone)}，身分證：{maskId(item.defendantIdNo)}
                         </Typography>
                         {item.location && (
                             <Typography variant="body2">

--- a/src/component/CaseCard.tsx
+++ b/src/component/CaseCard.tsx
@@ -121,7 +121,7 @@ const CaseCard: React.FC<Props> = ({ item }) => {
                                 地點：{item.location}
                                 {item.district || ''}
                                 {item.createdAt
-                                    ? ` ${new Date(item.createdAt).toLocaleDateString()}`
+                                    ? ` 時間：${new Date(item.createdAt).toLocaleDateString()}`
                                     : ''}
                                 {item.ip ? ` 來自：${item.ip}` : ''}
                             </Typography>

--- a/src/component/CaseCard.tsx
+++ b/src/component/CaseCard.tsx
@@ -118,12 +118,12 @@ const CaseCard: React.FC<Props> = ({ item }) => {
                         </Typography>
                         {item.location && (
                             <Typography variant="body2">
-                                {item.createdAt
-                                    ? `${new Date(item.createdAt).toLocaleDateString()} `
-                                    : ''}
                                 地點：{item.location}
                                 {item.district || ''}
-                                {item.ip ? ` IP：${item.ip}` : ''}
+                                {item.createdAt
+                                    ? ` ${new Date(item.createdAt).toLocaleDateString()}`
+                                    : ''}
+                                {item.ip ? ` 來自：${item.ip}` : ''}
                             </Typography>
                         )}
                     </Box>

--- a/src/component/CaseCard.tsx
+++ b/src/component/CaseCard.tsx
@@ -118,11 +118,11 @@ const CaseCard: React.FC<Props> = ({ item }) => {
                         </Typography>
                         {item.location && (
                             <Typography variant="body2">
+                                {item.createdAt
+                                    ? `${new Date(item.createdAt).toLocaleDateString()} `
+                                    : ''}
                                 地點：{item.location}
                                 {item.district || ''}
-                                {item.createdAt
-                                    ? ` ${new Date(item.createdAt).toLocaleDateString()}`
-                                    : ''}
                                 {item.ip ? ` IP：${item.ip}` : ''}
                             </Typography>
                         )}

--- a/src/component/CaseCard.tsx
+++ b/src/component/CaseCard.tsx
@@ -50,6 +50,7 @@ export interface CaseData {
     images?: string[];
     imageUrls?: string[];
     ip?: string;
+    createdAt?: string;
 }
 
 interface Props {
@@ -119,6 +120,9 @@ const CaseCard: React.FC<Props> = ({ item }) => {
                             <Typography variant="body2">
                                 地點：{item.location}
                                 {item.district || ''}
+                                {item.createdAt
+                                    ? ` ${new Date(item.createdAt).toLocaleDateString()}`
+                                    : ''}
                                 {item.ip ? ` IP：${item.ip}` : ''}
                             </Typography>
                         )}


### PR DESCRIPTION
## Summary
- show created date in case card location line
- support optional `createdAt` field in case data

## Testing
- `npm test --silent -- -w=0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858a90d6a20832d8d312068cd38e82c