### PR TITLE
Fix logout redirect on upload page

### DIFF
--- a/src/component/UserDataDialog.tsx
+++ b/src/component/UserDataDialog.tsx
@@ -8,6 +8,7 @@ import TextField from '@mui/material/TextField';
 
 import { useDispatch, useSelector } from 'react-redux';
 import { logout, setShowDialog, updateUserData } from '../redux/phoneSlice';
+import { useNavigate, useLocation } from 'react-router-dom';
 
 import { auth } from '../lib/firebase';
 import {
@@ -38,6 +39,8 @@ export function UserDataDialog() {
     }, [email]);
 
     const dispatch = useDispatch();
+    const navigate = useNavigate();
+    const location = useLocation();
     
     const handleClose = async () => {
         dispatch(setShowDialog(USER_DIALOG_STATUS.NONE));
@@ -53,9 +56,10 @@ export function UserDataDialog() {
     };
 
     const handleLogout = async () => {
-        dispatch(
-            logout()
-        );
+        dispatch(logout());
+        if (location.pathname === '/upload') {
+            navigate('/cases');
+        }
     };
 
     return (

--- a/src/pages/DiscussionPage.tsx
+++ b/src/pages/DiscussionPage.tsx
@@ -16,6 +16,12 @@ export default function DiscussionPage() {
         dispatch(fetchCaseList({}));
     }, [dispatch]);
 
+    useEffect(() => {
+        if (!isLoggedIn) {
+            setShowUpload(false);
+        }
+    }, [isLoggedIn]);
+
     return (
         <Box sx={{ mt: 0, p: 2 }}>
             {showUpload ? (


### PR DESCRIPTION
## Summary
- ensure logging out from the upload page redirects back to the blacklist
- hide the upload form in DiscussionPage when logged out

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859feecfe50832d87aeceac3749b3ed