### PR TITLE
Fix React Router warnings and memoize empty selectors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { store } from './redux';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import {
+    createBrowserRouter,
+    RouterProvider,
+    createRoutesFromElements,
+    Route,
+} from 'react-router-dom';
 
 import AppLayout from './layout/AppLayout';
 import AllLayout from './pages/HomePage'; // 原本首頁
@@ -11,21 +16,27 @@ import UploadCasePage from './pages/UploadCasePage';
 import DiscussionPage from './pages/DiscussionPage';
 
 export default function App() {
+    const router = createBrowserRouter(
+        createRoutesFromElements(
+            <Route path="/" element={<AppLayout />}>
+                <Route index element={<AllLayout />} />
+                <Route path="faq" element={<FAQPage />} />
+                <Route path="about" element={<AboutPage />} />
+                <Route path="cases" element={<DiscussionPage />} />
+                <Route path="upload" element={<UploadCasePage />} />
+            </Route>,
+        ),
+        {
+            future: {
+                v7_startTransition: true,
+                v7_relativeSplatPath: true,
+            },
+        },
+    );
+
     return (
         <Provider store={store}>
-            <Router>
-                <Routes>
-                    {/* 外層共用版型，內含 ButtonAppBar + Drawer */}
-                    <Route path="/" element={<AppLayout />}>
-                        <Route index element={<AllLayout />} />
-                        <Route path="faq" element={<FAQPage />} />
-                        <Route path="about" element={<AboutPage />} />
-                        <Route path="cases" element={<DiscussionPage />} />
-                        <Route path="upload" element={<UploadCasePage />} />
-                        {/* 其它既有子路由也搬進來即可 */}
-                    </Route>
-                </Routes>
-            </Router>
+            <RouterProvider router={router} />
         </Provider>
     );
 }

--- a/src/redux/caseCommentSlice.ts
+++ b/src/redux/caseCommentSlice.ts
@@ -104,5 +104,6 @@ const caseCommentSlice = createSlice({
 export const { clearCaseComments } = caseCommentSlice.actions;
 export default caseCommentSlice.reducer;
 
+const emptyCaseComments: CaseComment[] = [];
 export const selectCaseComments = (id: number) => (state: RootState) =>
-    state.caseComments.items[id] ?? [];
+    state.caseComments.items[id] ?? emptyCaseComments;

--- a/src/redux/commentSlice.ts
+++ b/src/redux/commentSlice.ts
@@ -106,5 +106,6 @@ export const { clearComments } = commentSlice.actions;
 export default commentSlice.reducer;
 
 // selector
+const emptyComments: Comment[] = [];
 export const selectCommentsByFileset = (id: number) => (state: RootState) =>
-    state.comments.items[id] ?? [];
+    state.comments.items[id] ?? emptyComments;


### PR DESCRIPTION
## Summary
- silence React Router future warnings by using `createBrowserRouter` with future flags
- avoid re-render warnings by returning constant empty arrays from comment selectors

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a1bf48118832d9e967837835cb3c7