### PR TITLE
Add search bar for rental blacklist

### DIFF
--- a/src/pages/DiscussionPage.tsx
+++ b/src/pages/DiscussionPage.tsx
@@ -1,9 +1,19 @@
 import React, { useEffect, useState } from 'react';
-import { Typography, Box, Fab } from '@mui/material';
+import {
+    Typography,
+    Box,
+    Fab,
+    TextField,
+    IconButton,
+    InputAdornment,
+    Snackbar,
+    Alert,
+} from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
 import AddIcon from '@mui/icons-material/Add';
 import CaseCardList from '../component/CaseCardList';
 import { useAppDispatch, useAppSelector } from '../hooks/redux';
-import { fetchCaseList } from '../redux/caseSlice';
+import { fetchCaseList, searchCaseList } from '../redux/caseSlice';
 import UploadCasePage from './UploadCasePage';
 
 export default function DiscussionPage() {
@@ -11,6 +21,24 @@ export default function DiscussionPage() {
     const cases = useAppSelector((s) => s.cases.list);
     const isLoggedIn = useAppSelector((s) => s.user.isLoggedIn);
     const [showUpload, setShowUpload] = useState(false);
+    const [search, setSearch] = useState('');
+    const [open, setOpen] = useState(false);
+
+    const handleSearch = () => {
+        dispatch(searchCaseList(search))
+            .unwrap()
+            .then((res) => {
+                if (!res || res.length === 0) {
+                    setOpen(true);
+                }
+            })
+            .catch(() => setOpen(true));
+    };
+
+    const handleClose = (_?: any, reason?: string) => {
+        if (reason === 'clickaway') return;
+        setOpen(false);
+    };
 
     useEffect(() => {
         dispatch(fetchCaseList({}));
@@ -39,6 +67,29 @@ export default function DiscussionPage() {
                         也可以新增租屋黑名單
                     </Typography>
                     {isLoggedIn && (
+                        <Box sx={{ my: 2, display: 'flex', justifyContent: 'center' }}>
+                            <TextField
+                                value={search}
+                                onChange={(e) => setSearch(e.target.value)}
+                                onKeyUp={(e) => {
+                                    if (e.key === 'Enter') handleSearch();
+                                }}
+                                label="搜尋黑名單"
+                                variant="outlined"
+                                sx={{ backgroundColor: 'white', width: '100%', maxWidth: 400 }}
+                                InputProps={{
+                                    endAdornment: (
+                                        <InputAdornment position="end">
+                                            <IconButton onClick={handleSearch} aria-label="search">
+                                                <SearchIcon />
+                                            </IconButton>
+                                        </InputAdornment>
+                                    ),
+                                }}
+                            />
+                        </Box>
+                    )}
+                    {isLoggedIn && (
                         <Fab
                             color="primary"
                             aria-label="add"
@@ -53,6 +104,11 @@ export default function DiscussionPage() {
                             <AddIcon />
                         </Fab>
                     )}
+                    <Snackbar open={open} autoHideDuration={3000} onClose={handleClose}>
+                        <Alert onClose={handleClose} severity="info" sx={{ width: '100%' }}>
+                            查無資料
+                        </Alert>
+                    </Snackbar>
                     <CaseCardList items={cases} />
                 </>
             )}

--- a/src/redux/caseSlice.ts
+++ b/src/redux/caseSlice.ts
@@ -13,6 +13,22 @@ export const fetchCaseList = createAsyncThunk<
     return response.data as CaseData[];
 });
 
+export const searchCaseList = createAsyncThunk<
+    CaseData[],
+    string,
+    { rejectValue: string }
+>('cases/searchCaseList', async (query, { rejectWithValue }) => {
+    try {
+        const token = localStorage.getItem('token');
+        const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
+        const url = `${CASE_API_URL}/search/${encodeURIComponent(query)}`;
+        const resp = await axios.get(url, config);
+        return resp.data as CaseData[];
+    } catch (e: any) {
+        return rejectWithValue(e.message);
+    }
+});
+
 export const caseSlice = createSlice({
     name: 'cases',
     initialState: {
@@ -34,6 +50,19 @@ export const caseSlice = createSlice({
                 },
             )
             .addCase(fetchCaseList.rejected, (state) => {
+                state.status = 'failed';
+            })
+            .addCase(searchCaseList.pending, (state) => {
+                state.status = 'loading';
+            })
+            .addCase(
+                searchCaseList.fulfilled,
+                (state, action: PayloadAction<CaseData[]>) => {
+                    state.status = 'succeeded';
+                    state.list = action.payload;
+                },
+            )
+            .addCase(searchCaseList.rejected, (state) => {
                 state.status = 'failed';
             });
     },


### PR DESCRIPTION
## Summary
- allow searching the rental blacklist by adding `searchCaseList`
- show a search box in the blacklist page that calls the new API
- show a Snackbar alert when no data is found

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cad2773f0832dbd3b55a756e52050