### PR TITLE
Fix success alert showing after refresh

### DIFF
--- a/src/redux/phoneSlice.ts
+++ b/src/redux/phoneSlice.ts
@@ -137,7 +137,9 @@ const phoneSlice = createSlice({
                 getUserData.fulfilled,
                 (state, action: PayloadAction<any>) => {
                     const { phone, ip, uid, name, email } = action.payload;
-                    state.fetchStatus = FETCH_STATUS.SUCCESS;
+                    // Do not trigger success alert when merely fetching user data
+                    // Ensure the fetch status is reset instead
+                    state.fetchStatus = FETCH_STATUS.NONE;
                     state.phone = phone;
                     state.isLoggedIn = true;
                     state.name = name;


### PR DESCRIPTION
## Summary
- prevent success snackbar from appearing just by loading user data

## Testing
- `npm test --silent -- -u --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e372d5cb0832d828cf839ec188802