### PR TITLE
Remove phone and ID requirement on upload

### DIFF
--- a/src/pages/UploadCasePage.tsx
+++ b/src/pages/UploadCasePage.tsx
@@ -171,13 +171,11 @@ export default function UploadCasePage({ onComplete }: UploadCasePageProps) {
                     label="黑名單電話"
                     value={form.defendantPhone}
                     onChange={handleInputChange('defendantPhone')}
-                    required
                 />
                 <TextField
                     label="黑名單身分證字號"
                     value={form.defendantIdNo}
                     onChange={handleInputChange('defendantIdNo')}
-                    required
                 />
                 <FormControl fullWidth>
                     <InputLabel id="location-label">縣市</InputLabel>

--- a/src/redux/uploadSlice.ts
+++ b/src/redux/uploadSlice.ts
@@ -17,8 +17,8 @@ export interface UploadPayload {
     title: string;
     content: string;
     defendantName: string;
-    defendantPhone: string;
-    defendantIdNo: string;
+    defendantPhone?: string;
+    defendantIdNo?: string;
     location: string;
     district: string;
     images: File[];
@@ -36,8 +36,12 @@ export const uploadCase = createAsyncThunk<
         formData.append('title', data.title);
         formData.append('content', data.content);
         formData.append('defendantName', data.defendantName);
-        formData.append('defendantPhone', data.defendantPhone);
-        formData.append('defendantIdNo', data.defendantIdNo);
+        if (data.defendantPhone) {
+            formData.append('defendantPhone', data.defendantPhone);
+        }
+        if (data.defendantIdNo) {
+            formData.append('defendantIdNo', data.defendantIdNo);
+        }
         formData.append('location', data.location);
         formData.append('district', data.district);
         data.images.forEach((f) => formData.append('images', f));


### PR DESCRIPTION
## Summary
- allow phone and ID number to be optional when uploading a case
- remove required validation in the upload form

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686003c32ff0832dbb12cfaee96746c9