### PR TITLE
Add login, register & forgot dialogs

### DIFF
--- a/src/component/CaseCard.tsx
+++ b/src/component/CaseCard.tsx
@@ -99,7 +99,7 @@ const CaseCard: React.FC<Props> = ({ item }) => {
 
     const handleToggleLike = () => {
         if (!isLoggedIn) {
-            dispatch(setShowDialog(USER_DIALOG_STATUS.PHONE_AUTH));
+            dispatch(setShowDialog(USER_DIALOG_STATUS.LOGIN));
             return;
         }
         if (!loading) {

--- a/src/component/CaseCommentForm.tsx
+++ b/src/component/CaseCommentForm.tsx
@@ -20,7 +20,7 @@ const CaseCommentForm: React.FC<Props> = ({ caseId }) => {
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         if (!isLoggedIn) {
-            dispatch(setShowDialog(USER_DIALOG_STATUS.PHONE_AUTH));
+            dispatch(setShowDialog(USER_DIALOG_STATUS.LOGIN));
             return;
         }
         if (!content.trim()) return;

--- a/src/component/CommentForm.tsx
+++ b/src/component/CommentForm.tsx
@@ -21,7 +21,7 @@ const CommentForm: React.FC<Props> = ({ filesetId }) => {
         e.preventDefault();
         if (!isLoggedIn) {
             // 觸發電話登入對話框
-            dispatch(setShowDialog(USER_DIALOG_STATUS.PHONE_AUTH));
+            dispatch(setShowDialog(USER_DIALOG_STATUS.LOGIN));
             return;
         }
         if (!content.trim()) return;

--- a/src/component/LoginDialog.tsx
+++ b/src/component/LoginDialog.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { Dialog, DialogTitle, DialogContent, TextField, DialogActions, Button } from '@mui/material';
+import { useDispatch, useSelector } from 'react-redux';
+import { loginUser, setShowDialog } from '../redux/phoneSlice';
+import { USER_DIALOG_STATUS } from '../types/enums';
+
+export function LoginDialog() {
+    const dispatch = useDispatch();
+    const { showDialog } = useSelector((state: any) => state.user);
+    const [phone, setPhone] = useState('');
+    const [password, setPassword] = useState('');
+
+    const handleClose = () => {
+        dispatch(setShowDialog(USER_DIALOG_STATUS.NONE));
+    };
+
+    const handleLogin = () => {
+        dispatch(loginUser({ phone, password }));
+    };
+
+    const handleRegister = () => {
+        dispatch(setShowDialog(USER_DIALOG_STATUS.REGISTER));
+    };
+
+    const handleForgot = () => {
+        dispatch(setShowDialog(USER_DIALOG_STATUS.FORGOT_PASSWORD));
+    };
+
+    return (
+        <Dialog open={showDialog === USER_DIALOG_STATUS.LOGIN} onClose={handleClose}>
+            <DialogTitle>登入</DialogTitle>
+            <DialogContent>
+                <TextField
+                    fullWidth
+                    margin="dense"
+                    label="電話"
+                    onChange={(e) => setPhone(e.target.value)}
+                />
+                <TextField
+                    fullWidth
+                    margin="dense"
+                    label="密碼"
+                    type="password"
+                    onChange={(e) => setPassword(e.target.value)}
+                />
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={handleRegister}>註冊</Button>
+                <Button onClick={handleForgot}>忘記密碼</Button>
+                <Button onClick={handleClose}>取消</Button>
+                <Button onClick={handleLogin}>登入</Button>
+            </DialogActions>
+        </Dialog>
+    );
+}

--- a/src/component/OutlinedCard.tsx
+++ b/src/component/OutlinedCard.tsx
@@ -78,7 +78,7 @@ export default function OutlinedCard(props: Props) {
         e: React.MouseEvent) => {
         e.stopPropagation();      // ← 阻止冒泡
         if (!isLoggedIn) {
-            dispatch(setShowDialog(USER_DIALOG_STATUS.PHONE_AUTH));
+            dispatch(setShowDialog(USER_DIALOG_STATUS.LOGIN));
             return;
         }
         if (!loading) {

--- a/src/component/PhoneAuthDialog.tsx
+++ b/src/component/PhoneAuthDialog.tsx
@@ -116,10 +116,10 @@ export function PhoneAuthDialog() {
 
     return (
         <div>
-            <Dialog open={showDialog === USER_DIALOG_STATUS.PHONE_AUTH} onClose={handleClose}>
-                <DialogTitle>電話登入</DialogTitle>
+            <Dialog open={showDialog === USER_DIALOG_STATUS.FORGOT_PASSWORD} onClose={handleClose}>
+                <DialogTitle>忘記密碼</DialogTitle>
                 <Typography variant="body1" sx={{ ml: 2, mt: 1 }}>
-                    用手機接收簡訊驗證碼即可登入發文留言
+                    用手機接收簡訊驗證碼以重設密碼
                 </Typography>
                 <DialogContent>
                     <Paper
@@ -169,7 +169,7 @@ export function PhoneAuthDialog() {
                 </DialogContent>
                 <DialogActions>
                     <Button sx={{ fontSize: '1rem' }} onClick={handleClose}>取消</Button>
-                    <Button sx={{ fontSize: '1rem' }} onClick={handleConfirmCode}>登入</Button>
+                    <Button sx={{ fontSize: '1rem' }} onClick={handleConfirmCode}>確認</Button>
                 </DialogActions>
             </Dialog>
             <div id="recaptcha-container" ref={recaptchaContainer}></div>

--- a/src/component/RegisterDialog.tsx
+++ b/src/component/RegisterDialog.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import { Dialog, DialogTitle, DialogContent, TextField, DialogActions, Button } from '@mui/material';
 import Typography from '@mui/material/Typography';
 import { useDispatch, useSelector } from 'react-redux';
-import { registerUser, setShowDialog } from '../redux/phoneSlice';
+import { registerUser, verifyPhoneNumber, setShowDialog } from '../redux/phoneSlice';
 import { USER_DIALOG_STATUS, FETCH_STATUS } from '../types/enums';
 import { auth } from '../lib/firebase';
 import { RecaptchaVerifier, signInWithPhoneNumber, ConfirmationResult } from 'firebase/auth';
@@ -75,6 +75,13 @@ export function RegisterDialog() {
                         phone,
                     })
                 ).unwrap();
+
+                await dispatch(
+                    verifyPhoneNumber({
+                        token: firebaseToken,
+                    })
+                ).unwrap();
+
                 handleClose();
             } catch (error) {
                 console.error(error);

--- a/src/component/RegisterDialog.tsx
+++ b/src/component/RegisterDialog.tsx
@@ -18,7 +18,16 @@ export function RegisterDialog() {
     };
 
     const handleSubmit = () => {
-        dispatch(registerUser({ token, password, name, displayName: name, email }));
+        dispatch(
+            registerUser({
+                token,
+                password,
+                name,
+                displayName: name,
+                email,
+                phone,
+            })
+        );
     };
 
     return (

--- a/src/component/RegisterDialog.tsx
+++ b/src/component/RegisterDialog.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { Dialog, DialogTitle, DialogContent, TextField, DialogActions, Button } from '@mui/material';
+import { useDispatch, useSelector } from 'react-redux';
+import { registerUser, setShowDialog } from '../redux/phoneSlice';
+import { USER_DIALOG_STATUS } from '../types/enums';
+
+export function RegisterDialog() {
+    const dispatch = useDispatch();
+    const { showDialog } = useSelector((state: any) => state.user);
+    const [token, setToken] = useState('');
+    const [password, setPassword] = useState('');
+    const [phone, setPhone] = useState('');
+    const [name, setName] = useState('');
+    const [email, setEmail] = useState('');
+
+    const handleClose = () => {
+        dispatch(setShowDialog(USER_DIALOG_STATUS.NONE));
+    };
+
+    const handleSubmit = () => {
+        dispatch(registerUser({ token, password, name, displayName: name, email }));
+    };
+
+    return (
+        <Dialog open={showDialog === USER_DIALOG_STATUS.REGISTER} onClose={handleClose}>
+            <DialogTitle>註冊</DialogTitle>
+            <DialogContent>
+                <TextField fullWidth margin="dense" label="電話" onChange={(e) => setPhone(e.target.value)} />
+                <TextField fullWidth margin="dense" label="密碼" type="password" onChange={(e) => setPassword(e.target.value)} />
+                <TextField fullWidth margin="dense" label="姓名" onChange={(e) => setName(e.target.value)} />
+                <TextField fullWidth margin="dense" label="Email" onChange={(e) => setEmail(e.target.value)} />
+                <TextField fullWidth margin="dense" label="驗證 Token" onChange={(e) => setToken(e.target.value)} />
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={handleClose}>取消</Button>
+                <Button onClick={handleSubmit}>註冊</Button>
+            </DialogActions>
+        </Dialog>
+    );
+}

--- a/src/component/RegisterDialog.tsx
+++ b/src/component/RegisterDialog.tsx
@@ -1,33 +1,84 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Dialog, DialogTitle, DialogContent, TextField, DialogActions, Button } from '@mui/material';
 import { useDispatch, useSelector } from 'react-redux';
 import { registerUser, setShowDialog } from '../redux/phoneSlice';
 import { USER_DIALOG_STATUS } from '../types/enums';
+import { auth } from '../lib/firebase';
+import { RecaptchaVerifier, signInWithPhoneNumber, ConfirmationResult } from 'firebase/auth';
 
 export function RegisterDialog() {
     const dispatch = useDispatch();
     const { showDialog } = useSelector((state: any) => state.user);
-    const [token, setToken] = useState('');
+    const [code, setCode] = useState('');
     const [password, setPassword] = useState('');
     const [phone, setPhone] = useState('');
     const [name, setName] = useState('');
     const [email, setEmail] = useState('');
+    const [confirmationResult, setConfirmationResult] = useState<ConfirmationResult | null>(null);
+    const recaptchaContainer = useRef(null);
+    const recaptchaVerifier = useRef<RecaptchaVerifier>();
+
+    useEffect(() => {
+        if (recaptchaContainer.current) {
+            recaptchaVerifier.current = new RecaptchaVerifier(
+                recaptchaContainer.current,
+                { size: 'invisible' },
+                auth
+            );
+        }
+
+        return () => {
+            if (recaptchaVerifier.current) {
+                recaptchaVerifier.current.clear();
+            }
+        };
+    }, []);
 
     const handleClose = () => {
         dispatch(setShowDialog(USER_DIALOG_STATUS.NONE));
     };
 
-    const handleSubmit = () => {
-        dispatch(
-            registerUser({
-                token,
-                password,
-                name,
-                displayName: name,
-                email,
-                phone,
-            })
+    const handleSendCode = async () => {
+        if (!recaptchaVerifier.current && recaptchaContainer.current) {
+            recaptchaVerifier.current = new RecaptchaVerifier(
+                recaptchaContainer.current,
+                { size: 'invisible' },
+                auth
+            );
+        }
+
+        if (!recaptchaVerifier.current) {
+            throw new Error('Unable to initialize recaptcha verifier.');
+        }
+
+        const result = await signInWithPhoneNumber(
+            auth,
+            '+886' + phone,
+            recaptchaVerifier.current
         );
+        setConfirmationResult(result);
+    };
+
+    const handleSubmit = async () => {
+        if (confirmationResult) {
+            try {
+                const result: any = await confirmationResult.confirm(code);
+                const firebaseToken = result.user.accessToken;
+                dispatch(
+                    registerUser({
+                        token: firebaseToken,
+                        password,
+                        name,
+                        displayName: name,
+                        email,
+                        phone,
+                    })
+                );
+                handleClose();
+            } catch (error) {
+                console.error(error);
+            }
+        }
     };
 
     return (
@@ -38,7 +89,18 @@ export function RegisterDialog() {
                 <TextField fullWidth margin="dense" label="密碼" type="password" onChange={(e) => setPassword(e.target.value)} />
                 <TextField fullWidth margin="dense" label="姓名" onChange={(e) => setName(e.target.value)} />
                 <TextField fullWidth margin="dense" label="Email" onChange={(e) => setEmail(e.target.value)} />
-                <TextField fullWidth margin="dense" label="驗證 Token" onChange={(e) => setToken(e.target.value)} />
+                <TextField
+                    fullWidth
+                    margin="dense"
+                    label="驗證 Token"
+                    onChange={(e) => setCode(e.target.value)}
+                    InputProps={{
+                        endAdornment: (
+                            <Button onClick={handleSendCode}>取得驗證碼</Button>
+                        ),
+                    }}
+                />
+                <div id="recaptcha-container" ref={recaptchaContainer}></div>
             </DialogContent>
             <DialogActions>
                 <Button onClick={handleClose}>取消</Button>

--- a/src/component/RegisterDialog.tsx
+++ b/src/component/RegisterDialog.tsx
@@ -1,14 +1,15 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Dialog, DialogTitle, DialogContent, TextField, DialogActions, Button } from '@mui/material';
+import Typography from '@mui/material/Typography';
 import { useDispatch, useSelector } from 'react-redux';
 import { registerUser, setShowDialog } from '../redux/phoneSlice';
-import { USER_DIALOG_STATUS } from '../types/enums';
+import { USER_DIALOG_STATUS, FETCH_STATUS } from '../types/enums';
 import { auth } from '../lib/firebase';
 import { RecaptchaVerifier, signInWithPhoneNumber, ConfirmationResult } from 'firebase/auth';
 
 export function RegisterDialog() {
     const dispatch = useDispatch();
-    const { showDialog } = useSelector((state: any) => state.user);
+    const { showDialog, fetchStatus, error } = useSelector((state: any) => state.user);
     const [code, setCode] = useState('');
     const [password, setPassword] = useState('');
     const [phone, setPhone] = useState('');
@@ -64,7 +65,7 @@ export function RegisterDialog() {
             try {
                 const result: any = await confirmationResult.confirm(code);
                 const firebaseToken = result.user.accessToken;
-                dispatch(
+                await dispatch(
                     registerUser({
                         token: firebaseToken,
                         password,
@@ -73,10 +74,11 @@ export function RegisterDialog() {
                         email,
                         phone,
                     })
-                );
+                ).unwrap();
                 handleClose();
             } catch (error) {
                 console.error(error);
+                // Do not close on failure so user can see the error
             }
         }
     };
@@ -101,6 +103,11 @@ export function RegisterDialog() {
                     }}
                 />
                 <div id="recaptcha-container" ref={recaptchaContainer}></div>
+                {fetchStatus === FETCH_STATUS.ERROR && (
+                    <Typography color="error" sx={{ mt: 1 }}>
+                        {error || '註冊失敗'}
+                    </Typography>
+                )}
             </DialogContent>
             <DialogActions>
                 <Button onClick={handleClose}>取消</Button>

--- a/src/component/UserDialog.tsx
+++ b/src/component/UserDialog.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
 import { useSelector } from 'react-redux';
+import { LoginDialog } from './LoginDialog';
+import { RegisterDialog } from './RegisterDialog';
 import { PhoneAuthDialog } from './PhoneAuthDialog';
 import { UserDataDialog } from './UserDataDialog';
 import { USER_DIALOG_STATUS } from '../types/enums';
@@ -13,8 +15,14 @@ export function UserDialog() {
 
     return (
         <div>
-            {showDialog === USER_DIALOG_STATUS.PHONE_AUTH && (
-                <PhoneAuthDialog/>
+            {showDialog === USER_DIALOG_STATUS.LOGIN && (
+                <LoginDialog />
+            )}
+            {showDialog === USER_DIALOG_STATUS.REGISTER && (
+                <RegisterDialog />
+            )}
+            {showDialog === USER_DIALOG_STATUS.FORGOT_PASSWORD && (
+                <PhoneAuthDialog />
             )}
             {showDialog === USER_DIALOG_STATUS.USER_DATA && (
                 <UserDataDialog/>

--- a/src/layout/ButtonAppBar.tsx
+++ b/src/layout/ButtonAppBar.tsx
@@ -35,7 +35,7 @@ export default function ButtonAppBar() {
 
     const handleClickOpen = () => {
         if(phone) dispatch(setShowDialog(USER_DIALOG_STATUS.USER_DATA));
-        else dispatch(setShowDialog(USER_DIALOG_STATUS.PHONE_AUTH));
+        else dispatch(setShowDialog(USER_DIALOG_STATUS.LOGIN));
     };
 
     return (

--- a/src/pages/DiscussionPage.tsx
+++ b/src/pages/DiscussionPage.tsx
@@ -27,7 +27,7 @@ export default function DiscussionPage() {
 
     const handleSearch = () => {
         if (!isLoggedIn) {
-            dispatch(setShowDialog(USER_DIALOG_STATUS.PHONE_AUTH));
+            dispatch(setShowDialog(USER_DIALOG_STATUS.LOGIN));
             return;
         }
         const query = search.trim();

--- a/src/pages/UploadCasePage.tsx
+++ b/src/pages/UploadCasePage.tsx
@@ -96,7 +96,7 @@ export default function UploadCasePage({ onComplete }: UploadCasePageProps) {
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
         if (!isLoggedIn) {
-            dispatch(setShowDialog(USER_DIALOG_STATUS.PHONE_AUTH));
+            dispatch(setShowDialog(USER_DIALOG_STATUS.LOGIN));
             return;
         }
         setSubmitDisabled(true);

--- a/src/redux/phoneSlice.ts
+++ b/src/redux/phoneSlice.ts
@@ -3,7 +3,7 @@ import axios, { AxiosError } from 'axios';
 import { FETCH_STATUS, USER_DIALOG_STATUS } from '../types/enums';
 
 const API_URL = process.env.REACT_APP_API_URL;
-const VERIFY_API_URL = `${API_URL}/verify`;
+const VERIFY_API_URL = `${API_URL}/user/verify`;
 const USER_API_URL = `${API_URL}/user`;
 
 export const loginUser: any = createAsyncThunk(

--- a/src/redux/phoneSlice.ts
+++ b/src/redux/phoneSlice.ts
@@ -6,6 +6,32 @@ const API_URL = process.env.REACT_APP_API_URL;
 const VERIFY_API_URL = `${API_URL}/verify`;
 const USER_API_URL = `${API_URL}/user`;
 
+export const loginUser: any = createAsyncThunk(
+    'user/login',
+    async (data, thunkAPI) => {
+        try {
+            const response = await axios.post(`${USER_API_URL}/login`, data);
+            return response.data;
+        } catch (error) {
+            const axiosError = error as AxiosError;
+            return thunkAPI.rejectWithValue(axiosError.response?.data);
+        }
+    }
+);
+
+export const registerUser: any = createAsyncThunk(
+    'user/register',
+    async (data, thunkAPI) => {
+        try {
+            const response = await axios.post(`${USER_API_URL}/register`, data);
+            return response.data;
+        } catch (error) {
+            const axiosError = error as AxiosError;
+            return thunkAPI.rejectWithValue(axiosError.response?.data);
+        }
+    }
+);
+
 // Create the async thunk for phone verification
 export const verifyPhoneNumber: any = createAsyncThunk(
     'phone/verify',
@@ -178,7 +204,34 @@ const phoneSlice = createSlice({
                     state.fetchStatus = FETCH_STATUS.ERROR;
                     state.error = action.payload.message;
                 }
-            );
+            )
+            .addCase(loginUser.pending, (state) => {
+                state.fetchStatus = FETCH_STATUS.LOADING;
+            })
+            .addCase(loginUser.fulfilled, (state, action: PayloadAction<any>) => {
+                const { phone, token, name, email } = action.payload;
+                state.fetchStatus = FETCH_STATUS.SUCCESS;
+                state.phone = phone;
+                state.token = token;
+                state.name = name;
+                state.email = email;
+                state.isLoggedIn = true;
+                localStorage.setItem('token', token);
+            })
+            .addCase(loginUser.rejected, (state, action: PayloadAction<any>) => {
+                state.fetchStatus = FETCH_STATUS.ERROR;
+                state.error = action.payload.message;
+            })
+            .addCase(registerUser.pending, (state) => {
+                state.fetchStatus = FETCH_STATUS.LOADING;
+            })
+            .addCase(registerUser.fulfilled, (state) => {
+                state.fetchStatus = FETCH_STATUS.SUCCESS;
+            })
+            .addCase(registerUser.rejected, (state, action: PayloadAction<any>) => {
+                state.fetchStatus = FETCH_STATUS.ERROR;
+                state.error = action.payload.message;
+            });
     },
 });
 export const { setTokenFromLocalStorage, setShowDialog, setFetchStatus, logout } = phoneSlice.actions;

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -1,6 +1,8 @@
 export enum USER_DIALOG_STATUS {
     NONE,
-    PHONE_AUTH,
+    LOGIN,
+    REGISTER,
+    FORGOT_PASSWORD,
     USER_DATA
 }
 


### PR DESCRIPTION
## Summary
- support `LOGIN`, `REGISTER`, and `FORGOT_PASSWORD` dialog states
- implement password login dialog
- implement user registration dialog
- repurpose phone auth dialog text for password recovery
- open login dialog when authentication is required

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863ea2ff43c832d9fc790179252e05e