### PR TITLE
Handle +886 login formatting

### DIFF
--- a/src/component/LoginDialog.tsx
+++ b/src/component/LoginDialog.tsx
@@ -24,13 +24,7 @@ export function LoginDialog() {
         dispatch(setShowDialog(USER_DIALOG_STATUS.NONE));
     };
 
-    const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        let value = e.target.value;
-        if (value.startsWith('0')) {
-            value = '+886' + value.slice(1);
-        }
-        setPhone(value);
-    };
+
 
     const handleLogin = () => {
         const formattedPhone = phone.startsWith('0')
@@ -59,7 +53,7 @@ export function LoginDialog() {
                     margin="dense"
                     label="電話"
                     value={phone}
-                    onChange={handlePhoneChange}
+                    onChange={(e) => setPhone(e.target.value)}
                 />
                 <TextField
                     fullWidth

--- a/src/component/LoginDialog.tsx
+++ b/src/component/LoginDialog.tsx
@@ -1,55 +1,85 @@
-import React, { useState } from 'react';
-import { Dialog, DialogTitle, DialogContent, TextField, DialogActions, Button } from '@mui/material';
-import { useDispatch, useSelector } from 'react-redux';
-import { loginUser, setShowDialog } from '../redux/phoneSlice';
-import { USER_DIALOG_STATUS } from '../types/enums';
+import React, { useState } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  TextField,
+  DialogActions,
+  Button,
+  Typography,
+} from "@mui/material";
+import { useDispatch, useSelector } from "react-redux";
+import { loginUser, setShowDialog } from "../redux/phoneSlice";
+import { USER_DIALOG_STATUS, FETCH_STATUS } from "../types/enums";
 
 export function LoginDialog() {
-    const dispatch = useDispatch();
-    const { showDialog } = useSelector((state: any) => state.user);
-    const [phone, setPhone] = useState('');
-    const [password, setPassword] = useState('');
+  const dispatch = useDispatch();
+  const { showDialog, fetchStatus, error } = useSelector(
+    (state: any) => state.user,
+  );
+  const [phone, setPhone] = useState("");
+  const [password, setPassword] = useState("");
 
-    const handleClose = () => {
-        dispatch(setShowDialog(USER_DIALOG_STATUS.NONE));
-    };
+  const handleClose = () => {
+    dispatch(setShowDialog(USER_DIALOG_STATUS.NONE));
+  };
 
-    const handleLogin = () => {
-        dispatch(loginUser({ phone, password }));
-    };
+  const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    let value = e.target.value;
+    if (value.startsWith("0")) {
+      value = "+886" + value.slice(1);
+    }
+    setPhone(value);
+  };
 
-    const handleRegister = () => {
-        dispatch(setShowDialog(USER_DIALOG_STATUS.REGISTER));
-    };
+  const handleLogin = () => {
+    const formattedPhone = phone.startsWith("0")
+      ? "+886" + phone.slice(1)
+      : phone;
+    dispatch(loginUser({ phone: formattedPhone, password }));
+  };
 
-    const handleForgot = () => {
-        dispatch(setShowDialog(USER_DIALOG_STATUS.FORGOT_PASSWORD));
-    };
+  const handleRegister = () => {
+    dispatch(setShowDialog(USER_DIALOG_STATUS.REGISTER));
+  };
 
-    return (
-        <Dialog open={showDialog === USER_DIALOG_STATUS.LOGIN} onClose={handleClose}>
-            <DialogTitle>登入</DialogTitle>
-            <DialogContent>
-                <TextField
-                    fullWidth
-                    margin="dense"
-                    label="電話"
-                    onChange={(e) => setPhone(e.target.value)}
-                />
-                <TextField
-                    fullWidth
-                    margin="dense"
-                    label="密碼"
-                    type="password"
-                    onChange={(e) => setPassword(e.target.value)}
-                />
-            </DialogContent>
-            <DialogActions>
-                <Button onClick={handleRegister}>註冊</Button>
-                <Button onClick={handleForgot}>忘記密碼</Button>
-                <Button onClick={handleClose}>取消</Button>
-                <Button onClick={handleLogin}>登入</Button>
-            </DialogActions>
-        </Dialog>
-    );
+  const handleForgot = () => {
+    dispatch(setShowDialog(USER_DIALOG_STATUS.FORGOT_PASSWORD));
+  };
+
+  return (
+    <Dialog
+      open={showDialog === USER_DIALOG_STATUS.LOGIN}
+      onClose={handleClose}
+    >
+      <DialogTitle>登入</DialogTitle>
+      <DialogContent>
+        <TextField
+          fullWidth
+          margin="dense"
+          label="電話"
+          value={phone}
+          onChange={handlePhoneChange}
+        />
+        <TextField
+          fullWidth
+          margin="dense"
+          label="密碼"
+          type="password"
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        {fetchStatus === FETCH_STATUS.ERROR && (
+          <Typography color="error" sx={{ mt: 1 }}>
+            {error || "登入失敗"}
+          </Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleRegister}>註冊</Button>
+        <Button onClick={handleForgot}>忘記密碼</Button>
+        <Button onClick={handleClose}>取消</Button>
+        <Button onClick={handleLogin}>登入</Button>
+      </DialogActions>
+    </Dialog>
+  );
 }

--- a/src/component/LoginDialog.tsx
+++ b/src/component/LoginDialog.tsx
@@ -24,8 +24,6 @@ export function LoginDialog() {
         dispatch(setShowDialog(USER_DIALOG_STATUS.NONE));
     };
 
-
-
     const handleLogin = () => {
         const formattedPhone = phone.startsWith('0')
             ? '+886' + phone.slice(1)

--- a/src/component/LoginDialog.tsx
+++ b/src/component/LoginDialog.tsx
@@ -1,85 +1,85 @@
-import React, { useState } from "react";
+import React, { useState } from 'react';
 import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  TextField,
-  DialogActions,
-  Button,
-  Typography,
-} from "@mui/material";
-import { useDispatch, useSelector } from "react-redux";
-import { loginUser, setShowDialog } from "../redux/phoneSlice";
-import { USER_DIALOG_STATUS, FETCH_STATUS } from "../types/enums";
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    TextField,
+    DialogActions,
+    Button,
+    Typography,
+} from '@mui/material';
+import { useDispatch, useSelector } from 'react-redux';
+import { loginUser, setShowDialog } from '../redux/phoneSlice';
+import { USER_DIALOG_STATUS, FETCH_STATUS } from '../types/enums';
 
 export function LoginDialog() {
-  const dispatch = useDispatch();
-  const { showDialog, fetchStatus, error } = useSelector(
-    (state: any) => state.user,
-  );
-  const [phone, setPhone] = useState("");
-  const [password, setPassword] = useState("");
+    const dispatch = useDispatch();
+    const { showDialog, fetchStatus, error } = useSelector(
+        (state: any) => state.user,
+    );
+    const [phone, setPhone] = useState('');
+    const [password, setPassword] = useState('');
 
-  const handleClose = () => {
-    dispatch(setShowDialog(USER_DIALOG_STATUS.NONE));
-  };
+    const handleClose = () => {
+        dispatch(setShowDialog(USER_DIALOG_STATUS.NONE));
+    };
 
-  const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    let value = e.target.value;
-    if (value.startsWith("0")) {
-      value = "+886" + value.slice(1);
-    }
-    setPhone(value);
-  };
+    const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        let value = e.target.value;
+        if (value.startsWith('0')) {
+            value = '+886' + value.slice(1);
+        }
+        setPhone(value);
+    };
 
-  const handleLogin = () => {
-    const formattedPhone = phone.startsWith("0")
-      ? "+886" + phone.slice(1)
-      : phone;
-    dispatch(loginUser({ phone: formattedPhone, password }));
-  };
+    const handleLogin = () => {
+        const formattedPhone = phone.startsWith('0')
+            ? '+886' + phone.slice(1)
+            : phone;
+        dispatch(loginUser({ phone: formattedPhone, password }));
+    };
 
-  const handleRegister = () => {
-    dispatch(setShowDialog(USER_DIALOG_STATUS.REGISTER));
-  };
+    const handleRegister = () => {
+        dispatch(setShowDialog(USER_DIALOG_STATUS.REGISTER));
+    };
 
-  const handleForgot = () => {
-    dispatch(setShowDialog(USER_DIALOG_STATUS.FORGOT_PASSWORD));
-  };
+    const handleForgot = () => {
+        dispatch(setShowDialog(USER_DIALOG_STATUS.FORGOT_PASSWORD));
+    };
 
-  return (
-    <Dialog
-      open={showDialog === USER_DIALOG_STATUS.LOGIN}
-      onClose={handleClose}
-    >
-      <DialogTitle>登入</DialogTitle>
-      <DialogContent>
-        <TextField
-          fullWidth
-          margin="dense"
-          label="電話"
-          value={phone}
-          onChange={handlePhoneChange}
-        />
-        <TextField
-          fullWidth
-          margin="dense"
-          label="密碼"
-          type="password"
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        {fetchStatus === FETCH_STATUS.ERROR && (
-          <Typography color="error" sx={{ mt: 1 }}>
-            {error || "登入失敗"}
-          </Typography>
-        )}
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={handleRegister}>註冊</Button>
-        <Button onClick={handleForgot}>忘記密碼</Button>
-        <Button onClick={handleClose}>取消</Button>
-        <Button onClick={handleLogin}>登入</Button>
-      </DialogActions>
-    </Dialog>
-  );
+    return (
+        <Dialog
+            open={showDialog === USER_DIALOG_STATUS.LOGIN}
+            onClose={handleClose}
+        >
+            <DialogTitle>登入</DialogTitle>
+            <DialogContent>
+                <TextField
+                    fullWidth
+                    margin="dense"
+                    label="電話"
+                    value={phone}
+                    onChange={handlePhoneChange}
+                />
+                <TextField
+                    fullWidth
+                    margin="dense"
+                    label="密碼"
+                    type="password"
+                    onChange={(e) => setPassword(e.target.value)}
+                />
+                {fetchStatus === FETCH_STATUS.ERROR && (
+                    <Typography color="error" sx={{ mt: 1 }}>
+                        {error || '登入失敗'}
+                    </Typography>
+                )}
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={handleRegister}>註冊</Button>
+                <Button onClick={handleForgot}>忘記密碼</Button>
+                <Button onClick={handleClose}>取消</Button>
+                <Button onClick={handleLogin}>登入</Button>
+            </DialogActions>
+        </Dialog>
+    );
 }

--- a/src/redux/phoneSlice.ts
+++ b/src/redux/phoneSlice.ts
@@ -216,6 +216,7 @@ const phoneSlice = createSlice({
                 state.name = name;
                 state.email = email;
                 state.isLoggedIn = true;
+                state.showDialog = USER_DIALOG_STATUS.NONE;
                 localStorage.setItem('token', token);
             })
             .addCase(loginUser.rejected, (state, action: PayloadAction<any>) => {


### PR DESCRIPTION
## Summary
- auto-replace leading `0` with `+886` during login
- show login failures in the login dialog

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865f994d55c832db890f4ec6904b117