### PR TITLE
Update register dialog UI

### DIFF
--- a/src/component/RegisterDialog.tsx
+++ b/src/component/RegisterDialog.tsx
@@ -14,6 +14,7 @@ export function RegisterDialog() {
     const [password, setPassword] = useState('');
     const [phone, setPhone] = useState('');
     const [name, setName] = useState('');
+    const [displayName, setDisplayName] = useState('');
     const [email, setEmail] = useState('');
     const [confirmationResult, setConfirmationResult] = useState<ConfirmationResult | null>(null);
     const recaptchaContainer = useRef(null);
@@ -52,9 +53,13 @@ export function RegisterDialog() {
             throw new Error('Unable to initialize recaptcha verifier.');
         }
 
+        const formattedPhone = phone.startsWith('0')
+            ? '+886' + phone.slice(1)
+            : phone;
+
         const result = await signInWithPhoneNumber(
             auth,
-            '+886' + phone,
+            formattedPhone,
             recaptchaVerifier.current
         );
         setConfirmationResult(result);
@@ -65,14 +70,19 @@ export function RegisterDialog() {
             try {
                 const result: any = await confirmationResult.confirm(code);
                 const firebaseToken = result.user.accessToken;
+
+                const formattedPhone = phone.startsWith('0')
+                    ? '+886' + phone.slice(1)
+                    : phone;
+
                 await dispatch(
                     registerUser({
                         token: firebaseToken,
                         password,
                         name,
-                        displayName: name,
+                        displayName,
                         email,
-                        phone,
+                        phone: formattedPhone,
                     })
                 ).unwrap();
 
@@ -94,20 +104,47 @@ export function RegisterDialog() {
         <Dialog open={showDialog === USER_DIALOG_STATUS.REGISTER} onClose={handleClose}>
             <DialogTitle>註冊</DialogTitle>
             <DialogContent>
-                <TextField fullWidth margin="dense" label="電話" onChange={(e) => setPhone(e.target.value)} />
-                <TextField fullWidth margin="dense" label="密碼" type="password" onChange={(e) => setPassword(e.target.value)} />
-                <TextField fullWidth margin="dense" label="姓名" onChange={(e) => setName(e.target.value)} />
-                <TextField fullWidth margin="dense" label="Email" onChange={(e) => setEmail(e.target.value)} />
                 <TextField
                     fullWidth
                     margin="dense"
-                    label="驗證 Token"
-                    onChange={(e) => setCode(e.target.value)}
+                    label="電話"
+                    onChange={(e) => setPhone(e.target.value)}
                     InputProps={{
                         endAdornment: (
                             <Button onClick={handleSendCode}>取得驗證碼</Button>
                         ),
                     }}
+                />
+                <TextField
+                    fullWidth
+                    margin="dense"
+                    label="驗證碼"
+                    onChange={(e) => setCode(e.target.value)}
+                />
+                <TextField
+                    fullWidth
+                    margin="dense"
+                    label="密碼"
+                    type="password"
+                    onChange={(e) => setPassword(e.target.value)}
+                />
+                <TextField
+                    fullWidth
+                    margin="dense"
+                    label="姓名"
+                    onChange={(e) => setName(e.target.value)}
+                />
+                <TextField
+                    fullWidth
+                    margin="dense"
+                    label="顯示名稱"
+                    onChange={(e) => setDisplayName(e.target.value)}
+                />
+                <TextField
+                    fullWidth
+                    margin="dense"
+                    label="Email"
+                    onChange={(e) => setEmail(e.target.value)}
                 />
                 <div id="recaptcha-container" ref={recaptchaContainer}></div>
                 {fetchStatus === FETCH_STATUS.ERROR && (

--- a/src/component/RegisterDialog.tsx
+++ b/src/component/RegisterDialog.tsx
@@ -109,19 +109,13 @@ export function RegisterDialog() {
                     margin="dense"
                     label="電話"
                     onChange={(e) => setPhone(e.target.value)}
+                    helperText="此電話需要通過驗證且日後不可修改"
                     InputProps={{
                         endAdornment: (
                             <Button onClick={handleSendCode}>取得驗證碼</Button>
                         ),
                     }}
                 />
-                <Typography
-                    variant="caption"
-                    color="text.secondary"
-                    sx={{ display: 'block', mb: 1 }}
-                >
-                    此電話需要通過驗證且日後不可修改
-                </Typography>
                 <TextField
                     fullWidth
                     margin="dense"
@@ -140,14 +134,8 @@ export function RegisterDialog() {
                     margin="dense"
                     label="姓名"
                     onChange={(e) => setName(e.target.value)}
+                    helperText="若日後需要修改姓名，請聯絡管理員"
                 />
-                <Typography
-                    variant="caption"
-                    color="text.secondary"
-                    sx={{ display: 'block', mb: 1 }}
-                >
-                    若日後需要修改姓名，請聯絡管理員
-                </Typography>
                 <TextField
                     fullWidth
                     margin="dense"
@@ -159,14 +147,8 @@ export function RegisterDialog() {
                     margin="dense"
                     label="Email"
                     onChange={(e) => setEmail(e.target.value)}
+                    helperText="若日後需要修改 Email，請聯絡管理員"
                 />
-                <Typography
-                    variant="caption"
-                    color="text.secondary"
-                    sx={{ display: 'block', mb: 1 }}
-                >
-                    若日後需要修改 Email，請聯絡管理員
-                </Typography>
                 <div id="recaptcha-container" ref={recaptchaContainer}></div>
                 {fetchStatus === FETCH_STATUS.ERROR && (
                     <Typography color="error" sx={{ mt: 1 }}>

--- a/src/component/RegisterDialog.tsx
+++ b/src/component/RegisterDialog.tsx
@@ -115,6 +115,13 @@ export function RegisterDialog() {
                         ),
                     }}
                 />
+                <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ display: 'block', mb: 1 }}
+                >
+                    此電話需要通過驗證且日後不可修改
+                </Typography>
                 <TextField
                     fullWidth
                     margin="dense"
@@ -134,6 +141,13 @@ export function RegisterDialog() {
                     label="姓名"
                     onChange={(e) => setName(e.target.value)}
                 />
+                <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ display: 'block', mb: 1 }}
+                >
+                    若日後需要修改姓名，請聯絡管理員
+                </Typography>
                 <TextField
                     fullWidth
                     margin="dense"
@@ -146,6 +160,13 @@ export function RegisterDialog() {
                     label="Email"
                     onChange={(e) => setEmail(e.target.value)}
                 />
+                <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ display: 'block', mb: 1 }}
+                >
+                    若日後需要修改 Email，請聯絡管理員
+                </Typography>
                 <div id="recaptcha-container" ref={recaptchaContainer}></div>
                 {fetchStatus === FETCH_STATUS.ERROR && (
                     <Typography color="error" sx={{ mt: 1 }}>

--- a/src/component/RegisterDialog.tsx
+++ b/src/component/RegisterDialog.tsx
@@ -109,7 +109,6 @@ export function RegisterDialog() {
                     margin="dense"
                     label="電話"
                     onChange={(e) => setPhone(e.target.value)}
-                    helperText="此電話需要通過驗證且日後不可修改"
                     InputProps={{
                         endAdornment: (
                             <Button onClick={handleSendCode}>取得驗證碼</Button>
@@ -134,7 +133,6 @@ export function RegisterDialog() {
                     margin="dense"
                     label="姓名"
                     onChange={(e) => setName(e.target.value)}
-                    helperText="若日後需要修改姓名，請聯絡管理員"
                 />
                 <TextField
                     fullWidth
@@ -147,7 +145,6 @@ export function RegisterDialog() {
                     margin="dense"
                     label="Email"
                     onChange={(e) => setEmail(e.target.value)}
-                    helperText="若日後需要修改 Email，請聯絡管理員"
                 />
                 <div id="recaptcha-container" ref={recaptchaContainer}></div>
                 {fetchStatus === FETCH_STATUS.ERROR && (


### PR DESCRIPTION
## Summary
- tweak register dialog to show verification button on phone input
- support display name and reorder fields
- update API phone formatting for Taiwan numbers

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686616260c3c832d9c4771dd6758d5b1