### PR TITLE
Implement user profile editing

### DIFF
--- a/src/component/UserDataDialog.tsx
+++ b/src/component/UserDataDialog.tsx
@@ -33,6 +33,12 @@ export function UserDataDialog() {
         }
     }, [displayName]);
 
+    useEffect(() => {
+        if (showDialog === USER_DIALOG_STATUS.USER_DATA) {
+            setPasswordInComponent('********');
+        }
+    }, [showDialog]);
+
     const dispatch = useDispatch();
     
     const handleClose = async () => {

--- a/src/component/UserDataDialog.tsx
+++ b/src/component/UserDataDialog.tsx
@@ -121,6 +121,11 @@ export function UserDataDialog() {
                         label="密碼"
                         type="password"
                         value={passwordInComponent}
+                        onFocus={() => {
+                            if (passwordInComponent === '********') {
+                                setPasswordInComponent('');
+                            }
+                        }}
                         onChange={(e) => setPasswordInComponent(e.target.value)}
                     />
                 </DialogContent>

--- a/src/component/UserDataDialog.tsx
+++ b/src/component/UserDataDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
@@ -9,32 +9,29 @@ import TextField from '@mui/material/TextField';
 import { useDispatch, useSelector } from 'react-redux';
 import { logout, setShowDialog, updateUserData } from '../redux/phoneSlice';
 
-import { auth } from '../lib/firebase';
-import {
-    ConfirmationResult,
-} from 'firebase/auth';
 import { USER_DIALOG_STATUS } from '../types/enums';
 
 export function UserDataDialog() {
-    const [nameInComponent, setNameInComponent] = useState('');
     const [emailInComponent, setEmailInComponent] = useState('');
+    const [displayNameInComponent, setDisplayNameInComponent] = useState('');
+    const [passwordInComponent, setPasswordInComponent] = useState('********');
 
 
-    const { phone, name, email, showDialog } = useSelector(
+    const { phone, name, email, displayName, showDialog } = useSelector(
         (state: any) => state.user
     );
-
-    useEffect(() => {
-        if (name) {
-            setNameInComponent(name);
-        }
-    }, [name]);
 
     useEffect(() => {
         if (email) {
             setEmailInComponent(email);
         }
     }, [email]);
+
+    useEffect(() => {
+        if (displayName) {
+            setDisplayNameInComponent(displayName);
+        }
+    }, [displayName]);
 
     const dispatch = useDispatch();
     
@@ -43,12 +40,14 @@ export function UserDataDialog() {
     };
 
     const handleConfirmData = async () => {
-        dispatch(
-            updateUserData({
-                name: nameInComponent,
-                email: emailInComponent
-            })
-        );
+        const payload: any = {
+            email: emailInComponent,
+            displayName: displayNameInComponent,
+        };
+        if (passwordInComponent !== '********' && passwordInComponent !== '') {
+            payload.password = passwordInComponent;
+        }
+        dispatch(updateUserData(payload));
     };
 
     const handleLogout = async () => {
@@ -79,11 +78,10 @@ export function UserDataDialog() {
                             color: 'gray',
                         }}
                         fullWidth
-                        required
-                        id="outlined-required"
+                        disabled
+                        id="outlined-disabled-name"
                         label="姓名"
                         defaultValue={name}
-                        onChange={(e) => setNameInComponent(e.target.value)}
                     />
                     <TextField
                         sx={{
@@ -91,11 +89,33 @@ export function UserDataDialog() {
                             color: 'gray',
                         }}
                         fullWidth
-                        required
+                        id="outlined-display-name"
+                        label="顯示名稱"
+                        value={displayNameInComponent}
+                        onChange={(e) => setDisplayNameInComponent(e.target.value)}
+                    />
+                    <TextField
+                        sx={{
+                            margin: '10px 0px',
+                            color: 'gray',
+                        }}
+                        fullWidth
                         id="outlined-required"
                         label="Email"
-                        defaultValue={email}
+                        value={emailInComponent}
                         onChange={(e) => setEmailInComponent(e.target.value)}
+                    />
+                    <TextField
+                        sx={{
+                            margin: '10px 0px',
+                            color: 'gray',
+                        }}
+                        fullWidth
+                        id="outlined-password"
+                        label="密碼"
+                        type="password"
+                        value={passwordInComponent}
+                        onChange={(e) => setPasswordInComponent(e.target.value)}
                     />
                 </DialogContent>
                 <DialogActions>

--- a/src/layout/ButtonAppBar.tsx
+++ b/src/layout/ButtonAppBar.tsx
@@ -29,7 +29,7 @@ export default function ButtonAppBar() {
         }
     }, [dispatch]);
 
-    const { phone } = useSelector(
+    const { phone, displayName } = useSelector(
         (state: any) => state.user
     );
 
@@ -73,7 +73,7 @@ export default function ButtonAppBar() {
                     <Box sx={{ flexGrow: 1 }} />
 
                     <Button color="inherit" style={{ fontSize: 18 }} onClick={handleClickOpen}>
-                        {phone ? phone : '登入'}
+                        {phone ? displayName || phone : '登入'}
                     </Button>
                     <UserDialog />
                 </Toolbar>

--- a/src/redux/phoneSlice.ts
+++ b/src/redux/phoneSlice.ts
@@ -59,7 +59,7 @@ export const updateUserData: any = createAsyncThunk(
                         Authorization: `Bearer ${token}`,
                     },
                 };
-                const response = await axios.post(USER_API_URL, data, config);
+                const response = await axios.put(USER_API_URL, data, config);
                 return response.data;
             }
         } catch (error) {
@@ -106,6 +106,7 @@ const phoneSlice = createSlice({
         showData: false,
         showDialog: USER_DIALOG_STATUS.NONE,
         name: '',
+        displayName: '',
         email: '',
         isLoggedIn: false,
     },
@@ -134,13 +135,14 @@ const phoneSlice = createSlice({
             .addCase(
                 verifyPhoneNumber.fulfilled,
                 (state, action: PayloadAction<any>) => {
-                    const { phone, ip, uid, token, name, email } = action.payload;
+                    const { phone, ip, uid, token, name, email, displayName } = action.payload;
                     state.fetchStatus = FETCH_STATUS.SUCCESS;
                     state.phone = phone;
                     state.isLoggedIn = true;
                     state.ip = ip;
                     state.uid = uid;
                     state.name = name;
+                    state.displayName = displayName || '';
                     state.email = email;
                     state.token = token;
 
@@ -162,13 +164,14 @@ const phoneSlice = createSlice({
             .addCase(
                 getUserData.fulfilled,
                 (state, action: PayloadAction<any>) => {
-                    const { phone, ip, uid, name, email } = action.payload;
+                    const { phone, ip, uid, name, email, displayName } = action.payload;
                     // Do not trigger success alert when merely fetching user data
                     // Ensure the fetch status is reset instead
                     state.fetchStatus = FETCH_STATUS.NONE;
                     state.phone = phone;
                     state.isLoggedIn = true;
                     state.name = name;
+                    state.displayName = displayName || '';
                     state.email = email;
                     state.ip = ip;
                     state.uid = uid;
@@ -188,9 +191,10 @@ const phoneSlice = createSlice({
             .addCase(
                 updateUserData.fulfilled,
                 (state, action: PayloadAction<any>) => {
-                    const { name, email, token } = action.payload;
+                    const { name, email, displayName, token } = action.payload;
                     state.fetchStatus = FETCH_STATUS.SUCCESS;
                     state.name = name;
+                    state.displayName = displayName || '';
                     state.email = email;
                     state.token = token;
 
@@ -209,11 +213,12 @@ const phoneSlice = createSlice({
                 state.fetchStatus = FETCH_STATUS.LOADING;
             })
             .addCase(loginUser.fulfilled, (state, action: PayloadAction<any>) => {
-                const { phone, token, name, email } = action.payload;
+                const { phone, token, name, email, displayName } = action.payload;
                 state.fetchStatus = FETCH_STATUS.SUCCESS;
                 state.phone = phone;
                 state.token = token;
                 state.name = name;
+                state.displayName = displayName || '';
                 state.email = email;
                 state.isLoggedIn = true;
                 state.showDialog = USER_DIALOG_STATUS.NONE;


### PR DESCRIPTION
## Summary
- extend Redux store with `displayName`
- allow PUT update of user data
- add fields for email, display name, and password in user dialog
- disable editing of name field

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run build --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68664347ab64832d963da1627bd686ff