### PR TITLE
Remove name from comments

### DIFF
--- a/src/component/CaseCommentList.tsx
+++ b/src/component/CaseCommentList.tsx
@@ -63,7 +63,7 @@ const CaseCommentList: React.FC<Props> = ({ caseId }) => {
                                     primary={c.content}
                                     secondary={
                                         <>
-                                            {c.name || '匿名'} ·{' '}
+                                            {c.displayName || '匿名'} ·{' '}
                                             {new Date(
                                                 c.createdAt,
                                             ).toLocaleString()}

--- a/src/component/CommentList.tsx
+++ b/src/component/CommentList.tsx
@@ -58,7 +58,7 @@ const CommentList: React.FC<Props> = ({ filesetId }) => {
                                     primary={c.content}
                                     secondary={
                                         <>
-                                            {c.name || '匿名'} ·{' '}
+                                            {c.displayName || '匿名'} ·{' '}
                                             {new Date(c.createdAt).toLocaleString()}
                                         </>
                                     }

--- a/src/redux/caseCommentSlice.ts
+++ b/src/redux/caseCommentSlice.ts
@@ -12,7 +12,7 @@ export interface CaseComment {
     caseId?: number;
     content: string;
     createdAt: string;
-    name?: string;
+    displayName?: string;
     email?: string;
     ip?: string;
 }

--- a/src/redux/commentSlice.ts
+++ b/src/redux/commentSlice.ts
@@ -11,7 +11,7 @@ export interface Comment {
   filesetId: number;
   content: string;
   createdAt: string;
-  name?: string;
+  displayName?: string;
   email?: string;
   ip?: string;
 }


### PR DESCRIPTION
## Summary
- remove deprecated `name` field from `Comment` and `CaseComment`
- rely on `displayName` when showing comments

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867863000b4832d8d8e462c16e4e5e8