### PR TITLE
Update search behavior and no-data display

### DIFF
--- a/src/component/CaseList.tsx
+++ b/src/component/CaseList.tsx
@@ -16,6 +16,7 @@ import JudicialFilesetComments from './JudicialFilesetComments';
 type Props = {
     items: any[];
     search: string;
+    status?: string;
 };
 
 type ListItemButtonProps = {
@@ -28,7 +29,7 @@ const ListItemButton = styled(ListItem)<ListItemButtonProps>(({ theme }) => ({
 }));
 
 function ExampleList(props: Props) {
-    const { items, search } = props;
+    const { items, search, status } = props;
     const [selectedItem, setSelectedItem] = useState<any | null>(null);
     const [openCommentId, setOpenCommentId] = useState<number | null>(null);
 
@@ -48,7 +49,7 @@ function ExampleList(props: Props) {
         setSelectedItem(null);
         setOpenCommentId(null);
     };
-    if (items.length === 0 && search.trim() !== '')
+    if (items.length === 0 && search.trim() !== '' && status === 'succeeded')
         return (
             <Box
                 display="flex"

--- a/src/component/SearchContent.tsx
+++ b/src/component/SearchContent.tsx
@@ -79,7 +79,6 @@ function App() {
                             fullWidth
                             onKeyUp={(event) => {
                                 if (event.key === 'Enter') {
-                                    executeSearch();
                                     event.preventDefault();
                                 }
                             }}

--- a/src/layout/ContentList.tsx
+++ b/src/layout/ContentList.tsx
@@ -25,13 +25,14 @@ type ApiResponse = {
 const YourComponent = () => {
     const cases = useSelector((state: any) => state.data.list);
     const searchCompare = useSelector((state: any) => state.data.searchCompare);
+    const dataStatus = useSelector((state: any) => state.data.status);
     const searchMode = useSelector((state: any) => state.data.searchMode);
     const results: ApiResponse[] = useSelector(
         (state: any) => state.search.results
     );
     return (
         <Box display="flex" flexDirection="column" alignItems="center">
-            <CaseList items={cases} search={searchCompare}></CaseList>
+            <CaseList items={cases} search={searchCompare} status={dataStatus}></CaseList>
             
         </Box>
     );

--- a/src/pages/DiscussionPage.tsx
+++ b/src/pages/DiscussionPage.tsx
@@ -83,7 +83,7 @@ export default function DiscussionPage() {
                                 value={search}
                                 onChange={(e) => setSearch(e.target.value)}
                                 onKeyUp={(e) => {
-                                    if (e.key === 'Enter') handleSearch();
+                                    if (e.key === 'Enter') e.preventDefault();
                                 }}
                                 label="搜尋黑名單"
                                 variant="outlined"


### PR DESCRIPTION
## Summary
- prevent executing search on Enter key
- show '查無資料' only after search completes with no results
- pass loading status to case list

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68678a28264c832d8f04a4ad716c3e9c