### PR TITLE
Remove onkeyup events

### DIFF
--- a/src/component/SearchContent.tsx
+++ b/src/component/SearchContent.tsx
@@ -77,11 +77,6 @@ function App() {
                             variant="outlined"
                             sx={{ backgroundColor: 'white' }} // 白色背景
                             fullWidth
-                            onKeyUp={(event) => {
-                                if (event.key === 'Enter') {
-                                    event.preventDefault();
-                                }
-                            }}
                             InputProps={{
                                 endAdornment: (
                                     <InputAdornment position="end">

--- a/src/pages/DiscussionPage.tsx
+++ b/src/pages/DiscussionPage.tsx
@@ -82,9 +82,6 @@ export default function DiscussionPage() {
                             <TextField
                                 value={search}
                                 onChange={(e) => setSearch(e.target.value)}
-                                onKeyUp={(e) => {
-                                    if (e.key === 'Enter') e.preventDefault();
-                                }}
                                 label="搜尋黑名單"
                                 variant="outlined"
                                 sx={{ backgroundColor: 'white', width: '100%', maxWidth: 400 }}


### PR DESCRIPTION
## Summary
- remove unused onKeyUp handlers from SearchContent and DiscussionPage

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867d29476b4832dbcf795f9f0d6eaf3