### PR TITLE
Add rent field to blacklist upload form

### DIFF
--- a/src/component/CaseCard.tsx
+++ b/src/component/CaseCard.tsx
@@ -118,11 +118,11 @@ const CaseCard: React.FC<Props> = ({ item }) => {
                             姓名：{maskName(item.defendantName)}，電話：
                             {item.defendantPhone && item.defendantPhone.trim()
                                 ? maskPhone(item.defendantPhone)
-                                : '無提供'}
+                                : '**********'}
                             ，身分證：
                             {item.defendantIdNo && item.defendantIdNo.trim()
                                 ? maskId(item.defendantIdNo)
-                                : '無提供'}
+                                : '**********'}
                         </Typography>
                         {item.location && (
                             <Typography variant="body2">

--- a/src/component/CaseCard.tsx
+++ b/src/component/CaseCard.tsx
@@ -43,8 +43,8 @@ export interface CaseData {
     title?: string;
     content?: string;
     defendantName: string;
-    defendantPhone: string;
-    defendantIdNo: string;
+    defendantPhone?: string;
+    defendantIdNo?: string;
     rent?: number;
     location?: string;
     district?: string;
@@ -115,7 +115,14 @@ const CaseCard: React.FC<Props> = ({ item }) => {
                 subheader={
                     <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                         <Typography variant="body2">
-                            姓名：{maskName(item.defendantName)}，電話：{maskPhone(item.defendantPhone)}，身分證：{maskId(item.defendantIdNo)}
+                            姓名：{maskName(item.defendantName)}，電話：
+                            {item.defendantPhone && item.defendantPhone.trim()
+                                ? maskPhone(item.defendantPhone)
+                                : '無提供'}
+                            ，身分證：
+                            {item.defendantIdNo && item.defendantIdNo.trim()
+                                ? maskId(item.defendantIdNo)
+                                : '無提供'}
                         </Typography>
                         {item.location && (
                             <Typography variant="body2">

--- a/src/component/CaseCard.tsx
+++ b/src/component/CaseCard.tsx
@@ -45,6 +45,7 @@ export interface CaseData {
     defendantName: string;
     defendantPhone: string;
     defendantIdNo: string;
+    rent?: number;
     location?: string;
     district?: string;
     images?: string[];
@@ -120,6 +121,7 @@ const CaseCard: React.FC<Props> = ({ item }) => {
                             <Typography variant="body2">
                                 地點：{item.location}
                                 {item.district || ''}
+                                {typeof item.rent === 'number' ? `，租金：${item.rent}` : ''}
                                 {item.createdAt
                                     ? `，時間：${new Date(item.createdAt).toLocaleDateString()}`
                                     : ''}

--- a/src/pages/UploadCasePage.tsx
+++ b/src/pages/UploadCasePage.tsx
@@ -39,6 +39,7 @@ export default function UploadCasePage({ onComplete }: UploadCasePageProps) {
         defendantName: string;
         defendantPhone: string;
         defendantIdNo: string;
+        rent: string;
         location: string;
         district: string;
         images: File[];
@@ -48,6 +49,7 @@ export default function UploadCasePage({ onComplete }: UploadCasePageProps) {
         defendantName: '',
         defendantPhone: '',
         defendantIdNo: '',
+        rent: '',
         location: '',
         district: '',
         images: [],
@@ -100,7 +102,12 @@ export default function UploadCasePage({ onComplete }: UploadCasePageProps) {
             return;
         }
         setSubmitDisabled(true);
-        dispatch(uploadCase(form));
+        dispatch(
+            uploadCase({
+                ...form,
+                rent: parseInt(form.rent, 10),
+            })
+        );
     };
 
     const handleClose = () => {
@@ -177,7 +184,14 @@ export default function UploadCasePage({ onComplete }: UploadCasePageProps) {
                     value={form.defendantIdNo}
                     onChange={handleInputChange('defendantIdNo')}
                 />
-                <FormControl fullWidth>
+                <TextField
+                    label="租金"
+                    type="number"
+                    value={form.rent}
+                    onChange={handleInputChange('rent')}
+                    required
+                />
+                <FormControl fullWidth required>
                     <InputLabel id="location-label">縣市</InputLabel>
                     <Select
                         labelId="location-label"

--- a/src/redux/uploadSlice.ts
+++ b/src/redux/uploadSlice.ts
@@ -19,6 +19,7 @@ export interface UploadPayload {
     defendantName: string;
     defendantPhone?: string;
     defendantIdNo?: string;
+    rent: number;
     location: string;
     district: string;
     images: File[];
@@ -42,6 +43,7 @@ export const uploadCase = createAsyncThunk<
         if (data.defendantIdNo) {
             formData.append('defendantIdNo', data.defendantIdNo);
         }
+        formData.append('rent', data.rent.toString());
         formData.append('location', data.location);
         formData.append('district', data.district);
         data.images.forEach((f) => formData.append('images', f));


### PR DESCRIPTION
## Summary
- allow specifying rent when uploading a blacklist case
- make location selection required

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e7e24218832db7aec625947ffc95