### PR TITLE
Fix display name button style

### DIFF
--- a/src/layout/ButtonAppBar.tsx
+++ b/src/layout/ButtonAppBar.tsx
@@ -72,7 +72,11 @@ export default function ButtonAppBar() {
 
                     <Box sx={{ flexGrow: 1 }} />
 
-                    <Button color="inherit" style={{ fontSize: 18 }} onClick={handleClickOpen}>
+                    <Button
+                        color="inherit"
+                        style={{ fontSize: 18, textTransform: 'none' }}
+                        onClick={handleClickOpen}
+                    >
                         {phone ? displayName || phone : '登入'}
                     </Button>
                     <UserDialog />


### PR DESCRIPTION
## Summary
- stop Material-UI `Button` from uppercasing display name

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873b7dbab14832db57e4afadca6140f