### PR TITLE
Fix mobile heading size for blacklist page

### DIFF
--- a/src/pages/DiscussionPage.tsx
+++ b/src/pages/DiscussionPage.tsx
@@ -82,7 +82,12 @@ export default function DiscussionPage() {
                 />
             ) : (
                 <>
-                    <Typography variant="h4" gutterBottom textAlign="center">
+                    <Typography
+                        variant="h4"
+                        gutterBottom
+                        textAlign="center"
+                        sx={{ fontSize: { xs: '1rem', md: '2.125rem' } }}
+                    >
                         租屋黑名單
                     </Typography>
                     {!isLoggedIn && (


### PR DESCRIPTION
## Summary
- adjust `租屋黑名單` heading to match body text size on small screens

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873c2b7a278832d93d8cb419b194d95