### PR TITLE
Fix mobile case title font size

### DIFF
--- a/src/component/CaseCard.tsx
+++ b/src/component/CaseCard.tsx
@@ -133,6 +133,7 @@ const CaseCard: React.FC<Props> = ({ item }) => {
         >
             <CardHeader
                 title={item.title || `姓名：${maskName(item.defendantName)}`}
+                titleTypographyProps={{ sx: { fontSize: { xs: '1rem' } } }}
                 subheader={
                     <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                         <Typography variant="body2">

--- a/src/component/OutlinedCard.tsx
+++ b/src/component/OutlinedCard.tsx
@@ -97,6 +97,7 @@ export default function OutlinedCard(props: Props) {
             <CardHeader
                 avatar={<BalanceIcon />}
                 title={jtitle}
+                titleTypographyProps={{ sx: { fontSize: { xs: '1rem' } } }}
                 subheader={`${jyear}年`}
             />
             <CardContent>


### PR DESCRIPTION
## Summary
- keep case title font size consistent with body text on mobile screens

## Testing
- `npm test -- --watchAll=false` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873c9380c8c832db41388470a73a39c