### PR TITLE
Set Traditional Chinese language for SMS auth

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -14,7 +14,7 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 
 export const auth = getAuth();
-auth.useDeviceLanguage();
+auth.languageCode = 'zh-TW';
 export const provider = new PhoneAuthProvider(auth);
 
 export default app;


### PR DESCRIPTION
## Summary
- ensure Firebase phone authentication uses the Taiwanese Traditional Chinese SMS template

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687473002b08832d9918722c2c534cfc